### PR TITLE
Remove use of relative_root_path variable

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -263,6 +263,6 @@ What we really want is an executable _description_ of our pipeline that
 allows software to do the tricky part for us: figuring out what tasks need to
 be run where and when, then perform those tasks for us.
 
-[ref-zipf]: {{ relative_root_path }}/reference#zipfs-law
+[ref-zipf]: ../reference#zipfs-law
 
 {% include links.md %}

--- a/_episodes/02-snakefiles.md
+++ b/_episodes/02-snakefiles.md
@@ -41,7 +41,7 @@ rule count_words:
 ~~~
 {: .language-python}
 
-This is a [build file](../reference#build-file), which for Snakemake is called a
+This is a [build file][ref-build-file], which for Snakemake is called a
 Snakefile - a file executed by Snakemake. Note that aside from a few keyword
 additions like `rule`, it follows standard Python 3 syntax.
 

--- a/_episodes/02-snakefiles.md
+++ b/_episodes/02-snakefiles.md
@@ -41,7 +41,7 @@ rule count_words:
 ~~~
 {: .language-python}
 
-This is a [build file](reference#build-file), which for Snakemake is called a
+This is a [build file](../reference#build-file), which for Snakemake is called a
 Snakefile - a file executed by Snakemake. Note that aside from a few keyword
 additions like `rule`, it follows standard Python 3 syntax.
 

--- a/_episodes/02-snakefiles.md
+++ b/_episodes/02-snakefiles.md
@@ -41,7 +41,7 @@ rule count_words:
 ~~~
 {: .language-python}
 
-This is a [build file][ref-build-file], which for Snakemake is called a
+This is a [build file](reference#build-file), which for Snakemake is called a
 Snakefile - a file executed by Snakemake. Note that aside from a few keyword
 additions like `rule`, it follows standard Python 3 syntax.
 

--- a/_episodes/02-snakefiles.md
+++ b/_episodes/02-snakefiles.md
@@ -547,16 +547,16 @@ The following figure shows the dependencies embodied within our Snakefile,
 involved in building the `results.txt` target:
 ![Dependencies represented within the Snakefile][fig-challenge]
 
-[ref-build-file]: {{ relative_root_path }}/reference#build-file
-[ref-target]: {{ relative_root_path }}/reference#target
-[ref-rule]: {{ relative_root_path }}/reference#rule
-[ref-incremental]: {{ relative_root_path }}/reference#incremental-builds
-[ref-dag]: {{ relative_root_path }}/reference#directed-acyclic-graph
-[ref-dependency]: {{ relative_root_path }}/reference#dependency
-[ref-default-target]: {{ relative_root_path }}/reference#default-target
-[ref-action]: {{ relative_root_path }}/reference#action
+[ref-build-file]: ../reference#build-file
+[ref-target]: ../reference#target
+[ref-rule]: ../reference#rule
+[ref-incremental]: ../reference#incremental-builds
+[ref-dag]: ../reference#directed-acyclic-graph
+[ref-dependency]: ../reference#dependency
+[ref-default-target]: ../reference#default-target
+[ref-action]: ../reference#action
 [snakemake]: https://snakemake.readthedocs.io/en/stable/
-[fig-challenge]: {{ relative_root_path }}/fig/02-challenge-dag.svg
-[fig-dats]: {{ relative_root_path }}/fig/02-dats-dag.svg
+[fig-challenge]: ../fig/02-challenge-dag.svg
+[fig-dats]: ../fig/02-dats-dag.svg
 
 {% include links.md %}

--- a/_episodes/03-wildcards.md
+++ b/_episodes/03-wildcards.md
@@ -414,6 +414,6 @@ steps.
 > {: .solution}
 {: .challenge}
 
-[ref-wildcard]: {{ relative_root_path }}/reference#wildcard
+[ref-wildcard]: ../reference#wildcard
 
 {% include links.md %}

--- a/_episodes/04-patterns.md
+++ b/_episodes/04-patterns.md
@@ -149,8 +149,8 @@ identified all three inputs to the `count_words` rule, and the value of the
 `{book}` wildcard is displayed:
 ![Dependencies represented within the Snakefile when using a pattern rule][fig-pattern-rule]
 
-[ref-pattern-rule]: {{ relative_root_path }}/reference#pattern-rule
-[ref-wildcard]: {{ relative_root_path }}/reference#wildcard
-[fig-pattern-rule]: {{ relative_root_path }}/fig/04-pattern-dag.svg
+[ref-pattern-rule]: ../reference#pattern-rule
+[ref-wildcard]: ../reference#wildcard
+[fig-pattern-rule]: ../fig/04-pattern-dag.svg
 
 {% include links.md %}

--- a/_episodes/05-snakemake-python.md
+++ b/_episodes/05-snakemake-python.md
@@ -423,8 +423,8 @@ Finished job 0.
 > This can be useful when you just want to see your own output.
 {:.callout}
 
-[ref-dependency]: {{ relative_root_path }}/reference#dependency
-[ref-target]: {{ relative_root_path }}/reference#target
-[ref-action]: {{ relative_root_path }}/reference#action
+[ref-dependency]: ../reference#dependency
+[ref-target]: ../reference#target
+[ref-action]: ../reference#action
 
 {% include links.md %}

--- a/_episodes/06-remaining-stages.md
+++ b/_episodes/06-remaining-stages.md
@@ -315,6 +315,6 @@ After these exercises our final workflow should look something like the followin
 > * check the results.txt file to see how this book compares to the others
 {: .challenge}
 
-[fig-final-dag]: {{ relative_root_path }}/fig/06-final-dag.svg
+[fig-final-dag]: ../fig/06-final-dag.svg
 
 {% include links.md %}

--- a/_episodes/09-cluster.md
+++ b/_episodes/09-cluster.md
@@ -361,8 +361,8 @@ Now, let's dissect the command we just ran:
 > Is this a good idea? What are some problems of this approach?
 {:.discussion}
 
-[ref-hpc-cluster]: {{ relative_root_path }}/reference#hpc-cluster
-[ref-scheduler]: {{ relative_root_path }}/reference#scheduler
+[ref-hpc-cluster]: ../reference#hpc-cluster
+[ref-scheduler]: ../reference#scheduler
 [cluster-config-docs]: https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html#cluster-configuration
 
 {% include links.md %}

--- a/index.md
+++ b/index.md
@@ -45,7 +45,7 @@ of these Carpentry courses:
 
 > ## Setup
 >
-> Please follow the instructions in the [Setup page][setup].
+> Please follow the instructions in the [Setup page][lesson-setup].
 >
 > The files used in this lesson can be downloaded:
 >

--- a/index.md
+++ b/index.md
@@ -45,7 +45,7 @@ of these Carpentry courses:
 
 > ## Setup
 >
-> Please follow the instructions in the [Setup page][lesson-setup].
+> Please follow the instructions in the [Setup page][setup].
 >
 > The files used in this lesson can be downloaded:
 >

--- a/index.md
+++ b/index.md
@@ -45,7 +45,7 @@ of these Carpentry courses:
 
 > ## Setup
 >
-> Please follow the instructions in the [Setup page][lesson-setup].
+> Please follow the instructions in the [Setup page](setup).
 >
 > The files used in this lesson can be downloaded:
 >


### PR DESCRIPTION
relative_root_path as defined in _includes/base_path cannot be used in episodes,
due to 
https://github.com/carpentries/styles/issues/419
