### PR TITLE
Fix deprecated import of `collections.Sequence` in `plotcount.py`

### DIFF
--- a/code/plotcount.py
+++ b/code/plotcount.py
@@ -5,7 +5,7 @@ import matplotlib
 matplotlib.use("AGG")
 import matplotlib.pyplot as plt
 import sys
-from collections import Sequence
+from collections.abc import Sequence
 
 from wordcount import load_word_counts
 


### PR DESCRIPTION
Hi :wave:,

Just starting to work through the lesson, thanks for creating it! Here is one small fix that I hope will help keep the lesson up-to-date.

- Importing abcs directly from `collections` has been [deprecated from Python 3.3 to Python3.9](https://github.com/python/cpython/issues/83855), and removed in 3.10
- This commit updates the import to be compatible with Python 3.10
- Alternatively, the import could switch on Python versions to keep backwards compatibility