### PR TITLE
Update wildcard name in workflow output

### DIFF
--- a/_episodes/04-patterns.md
+++ b/_episodes/04-patterns.md
@@ -76,7 +76,7 @@ rule count_words:
     input: wordcount.py, books/sierra.txt
     output: sierra.dat
     jobid: 0
-    wildcards: file=sierra
+    wildcards: book=sierra
 
 python wordcount.py books/sierra.txt sierra.dat
 Finished job 0.


### PR DESCRIPTION
In episode 4 (Patterns):

- The wildcard is called `book`, not `file` 🙂