### PR TITLE
[Episode 5] Fix placement of `--quiet` arg

### DIFF
--- a/_episodes/05-snakemake-python.md
+++ b/_episodes/05-snakemake-python.md
@@ -392,7 +392,7 @@ Upon execution of the corresponding rule, Snakemake runs our Python code
 in the `run:` block:
 
 ~~~
-snakemake --quiet print_book_names
+snakemake print_book_names --quiet
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
- In version `7.18.2` of `snakemake`, the original command `snakemake --quiet print_book_names` throws an error:

```bash
snakemake: error: argument --quiet/-q: invalid choice: 'print_book_names' (choose from 'progress', 'rules', 'all')
```

It seems that at some point, the `---quiet` argument was modified to take further qualifications (i.e., what should not be printed). The error comes from `print_book_names` not being in the list of valid strings `[progress, rules, all]`. To avoid this, use `--quiet` at the end of the command.
